### PR TITLE
included * into npmjs tarball

### DIFF
--- a/package.src.json
+++ b/package.src.json
@@ -8,7 +8,7 @@
     "url" : "https://github.com/anonyco/BestBase64EncoderDecoder/issues",
     "email" : "wowzeryest@gmail.com"
   },
-  "liscence": "Unlicense",
+  "license": "Unlicense",
   "author": {
     "name" : "Jack Giffin",
     "email" : "wowzeryest@gmail.com",
@@ -18,7 +18,6 @@
   "repository": {
     "type" : "git",
     "url" : "https://github.com/anonyco/BestBase64EncoderDecoder.git"
-  },
-  "files": ["atobAndBtoaTogether.node.js"]
+  }
 }
 


### PR DESCRIPTION
& fixed a typo
The package only includes the NodeJS variant, which might not be the one everybody wants to import.
NPM users already have to deal with ten thousands if not hundred thousands of files in their node_modules folder, but these few more files won't hurt anybody; in fact they will increase the amount of formats to choose from.